### PR TITLE
Add span structure

### DIFF
--- a/sample/Sky.Apm.Sample.Logging/Controllers/WeatherForecastController.cs
+++ b/sample/Sky.Apm.Sample.Logging/Controllers/WeatherForecastController.cs
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using Microsoft.AspNetCore.Mvc;
+using SkyApm.Diagnostics.Logging;
+using SkyApm.Tracing;
+
+namespace Sky.Apm.Sample.Logging.Controllers
+{
+    [ApiController]
+    [Route("apitest")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = new[]
+        {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+        private readonly Test _test;
+        private readonly ISkyApmLogger<WeatherForecastController> _skyApmLogger;
+        public WeatherForecastController(ISkyApmLogger<WeatherForecastController> skyApmLogger, Test test)
+        {
+            _skyApmLogger = skyApmLogger;
+            _test = test;
+        }
+
+        [HttpGet(Name = "GetWeatherForecast")]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            //Console.WriteLine(_entrySegmentContextAccessor.Context?.TraceId);
+            _skyApmLogger.Information("下订单成功！");
+            _test.Create();
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+    }
+}

--- a/sample/Sky.Apm.Sample.Logging/Program.cs
+++ b/sample/Sky.Apm.Sample.Logging/Program.cs
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+using Sky.Apm.Sample.Logging;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddScoped<Test>();
+builder.Services.AddPushSkyApmLogger(x => x.Enable = true);
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/sample/Sky.Apm.Sample.Logging/Properties/launchSettings.json
+++ b/sample/Sky.Apm.Sample.Logging/Properties/launchSettings.json
@@ -1,0 +1,32 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:2952",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "Sky.Apm.Sample.Logging": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5008",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "SkyAPM.Agent.AspNetCore"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/sample/Sky.Apm.Sample.Logging/Sky.Apm.Sample.Logging.csproj
+++ b/sample/Sky.Apm.Sample.Logging/Sky.Apm.Sample.Logging.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Test\**" />
+    <Content Remove="Test\**" />
+    <EmbeddedResource Remove="Test\**" />
+    <None Remove="Test\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SkyApm.Agent.AspNetCore\SkyApm.Agent.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\SkyApm.Diagnostics.Logging\SkyApm.Diagnostics.Logging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sample/Sky.Apm.Sample.Logging/Test.cs
+++ b/sample/Sky.Apm.Sample.Logging/Test.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Sky.Apm.Sample.Logging
+{
+    public class Test
+    {
+        private readonly ILogger _logger;
+
+        public Test(ILogger<Test> logger)
+        {
+            _logger = logger;
+        }
+
+        public void Create()
+        {
+            _logger.LogError("创建了一个用户对象",new List<string> { "asdasdas","3ewqeqdad","q34asdase2qq"});
+        }
+    }
+}

--- a/sample/Sky.Apm.Sample.Logging/WeatherForecast.cs
+++ b/sample/Sky.Apm.Sample.Logging/WeatherForecast.cs
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Sky.Apm.Sample.Logging
+{
+    public class WeatherForecast
+    {
+        public DateTime Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+        public string? Summary { get; set; }
+    }
+}

--- a/sample/Sky.Apm.Sample.Logging/appsettings.Development.json
+++ b/sample/Sky.Apm.Sample.Logging/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/sample/Sky.Apm.Sample.Logging/appsettings.json
+++ b/sample/Sky.Apm.Sample.Logging/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/sample/Sky.Apm.Sample.Logging/skyapm.json
+++ b/sample/Sky.Apm.Sample.Logging/skyapm.json
@@ -1,0 +1,30 @@
+{
+  "SkyWalking": {
+    "ServiceName": "Sky.Apm.Sample.Logging",
+    "Namespace": "",
+    "HeaderVersions": [
+      "sw8"
+    ],
+    "Sampling": {
+      "SamplePer3Secs": -1,
+      "Percentage": -1.0
+    },
+    "Logging": {
+      "Level": "Information",
+      "FilePath": "logs\\skyapm-{Date}.log"
+    },
+    "Transport": {
+      "Interval": 3000,
+      "ProtocolVersion": "v8",
+      "QueueSize": 30000,
+      "BatchSize": 3000,
+      "gRPC": {
+        "Servers": "101.34.26.221:40009",
+        "Timeout": 10000,
+        "ConnectTimeout": 10000,
+        "ReportTimeout": 600000 //,
+        //"Authentication": ""
+      }
+    }
+  }
+}

--- a/skyapm-dotnet.sln
+++ b/skyapm-dotnet.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28729.10
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32407.343
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{05BF0D4E-C824-4EC8-8330-36C1FC49910E}"
 EndProject
@@ -108,6 +108,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkyApm.Diagnostics.FreeSql", "src\SkyApm.Diagnostics.FreeSql\SkyApm.Diagnostics.FreeSql.csproj", "{82580A47-9DBC-43E8-B581-0C35147B4FAD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SkyApm.Sample.FreeSqlSqlite", "sample\SkyApm.Sample.FreeSql\SkyApm.Sample.FreeSqlSqlite.csproj", "{B1EF3295-4BF0-489F-8063-C9E3DAE20AA9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sky.Apm.Sample.Logging", "sample\Sky.Apm.Sample.Logging\Sky.Apm.Sample.Logging.csproj", "{D35905EC-EB46-4A3D-BD2B-02C4C868BC65}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkyApm.Diagnostics.Logging", "src\SkyApm.Diagnostics.Logging\SkyApm.Diagnostics.Logging.csproj", "{DDF18F43-E1D2-4854-AC97-DFC321EF6563}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -243,6 +247,14 @@ Global
 		{B1EF3295-4BF0-489F-8063-C9E3DAE20AA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B1EF3295-4BF0-489F-8063-C9E3DAE20AA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1EF3295-4BF0-489F-8063-C9E3DAE20AA9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D35905EC-EB46-4A3D-BD2B-02C4C868BC65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D35905EC-EB46-4A3D-BD2B-02C4C868BC65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D35905EC-EB46-4A3D-BD2B-02C4C868BC65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D35905EC-EB46-4A3D-BD2B-02C4C868BC65}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDF18F43-E1D2-4854-AC97-DFC321EF6563}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDF18F43-E1D2-4854-AC97-DFC321EF6563}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDF18F43-E1D2-4854-AC97-DFC321EF6563}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDF18F43-E1D2-4854-AC97-DFC321EF6563}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -289,6 +301,8 @@ Global
 		{8D3C5573-C282-45F5-A7F4-2E323F322CB7} = {B5E677CF-2920-4B0A-A056-E73F6B2CF2BC}
 		{82580A47-9DBC-43E8-B581-0C35147B4FAD} = {B5E677CF-2920-4B0A-A056-E73F6B2CF2BC}
 		{B1EF3295-4BF0-489F-8063-C9E3DAE20AA9} = {844CEACD-4C85-4B15-9E2B-892B01FDA4BB}
+		{D35905EC-EB46-4A3D-BD2B-02C4C868BC65} = {844CEACD-4C85-4B15-9E2B-892B01FDA4BB}
+		{DDF18F43-E1D2-4854-AC97-DFC321EF6563} = {B5E677CF-2920-4B0A-A056-E73F6B2CF2BC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {94C0DA2C-CCCB-4314-93A2-9809B5DD0583}

--- a/src/SkyApm.Abstractions/Config/LogPushSkywalkingConfig.cs
+++ b/src/SkyApm.Abstractions/Config/LogPushSkywalkingConfig.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace SkyApm.Config
+{
+    public class LogPushSkywalkingConfig
+    {
+        public bool Enable { get; set; }
+    }
+}

--- a/src/SkyApm.Abstractions/Tracing/Segments/LoggerContext.cs
+++ b/src/SkyApm.Abstractions/Tracing/Segments/LoggerContext.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System.Collections.Generic;
+
+namespace SkyApm.Tracing.Segments
+{
+    public class LoggerContext
+    {
+        public Dictionary<string, object> Logs { get; set; }
+
+        public SegmentContext SegmentContext { get; set; }
+    }
+}

--- a/src/SkyApm.Abstractions/Tracing/Segments/LoggerContext.cs
+++ b/src/SkyApm.Abstractions/Tracing/Segments/LoggerContext.cs
@@ -16,6 +16,7 @@
  *
  */
 
+using System;
 using System.Collections.Generic;
 
 namespace SkyApm.Tracing.Segments
@@ -25,5 +26,7 @@ namespace SkyApm.Tracing.Segments
         public Dictionary<string, object> Logs { get; set; }
 
         public SegmentContext SegmentContext { get; set; }
+
+        public long Date { get; set; }
     }
 }

--- a/src/SkyApm.Abstractions/Transport/ILoggerContextContextMapper.cs
+++ b/src/SkyApm.Abstractions/Transport/ILoggerContextContextMapper.cs
@@ -1,0 +1,26 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Tracing.Segments;
+namespace SkyApm.Transport
+{
+    public interface ILoggerContextContextMapper
+    {
+        LoggerRequest Map(LoggerContext loggerContext);
+    }
+}

--- a/src/SkyApm.Abstractions/Transport/ILoggerReporter.cs
+++ b/src/SkyApm.Abstractions/Transport/ILoggerReporter.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SkyApm.Transport
+{
+    public interface ILoggerReporter
+    {
+        Task ReportAsync(IReadOnlyCollection<LoggerRequest> loggerRequests,
+           CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/SkyApm.Abstractions/Transport/ISkyApmLogDispatcher.cs
+++ b/src/SkyApm.Abstractions/Transport/ISkyApmLogDispatcher.cs
@@ -1,0 +1,34 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Tracing.Segments;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SkyApm.Transport
+{
+    public interface ISkyApmLogDispatcher
+    {
+        bool Dispatch(LoggerContext loggerContext);
+
+        Task Flush(CancellationToken token = default(CancellationToken));
+
+        void Close();
+
+    }
+}

--- a/src/SkyApm.Abstractions/Transport/LoggerRequest.cs
+++ b/src/SkyApm.Abstractions/Transport/LoggerRequest.cs
@@ -27,5 +27,7 @@ namespace SkyApm.Transport
         public Dictionary<string, object> Logs { get; set; }
 
         public SegmentRequest SegmentRequest { get; set; }
+
+        public long Date { get; set; }
     }
 }

--- a/src/SkyApm.Abstractions/Transport/LoggerRequest.cs
+++ b/src/SkyApm.Abstractions/Transport/LoggerRequest.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SkyApm.Transport
+{
+    public class LoggerRequest
+    {
+        public Dictionary<string, object> Logs { get; set; }
+
+        public SegmentRequest SegmentRequest { get; set; }
+    }
+}

--- a/src/SkyApm.Agent.Hosting/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SkyApm.Agent.Hosting/Extensions/ServiceCollectionExtensions.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Extensions.DependencyInjection
             return services;
         }
 
+        
+
         internal static IServiceCollection AddSkyAPMCore(this IServiceCollection services, Action<SkyApmExtensions> extensionsSetup = null)
         {
             if (services == null)
@@ -56,6 +58,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddSingleton<ISegmentDispatcher, AsyncQueueSegmentDispatcher>();
             services.AddSingleton<IExecutionService, RegisterService>();
+            services.AddSingleton<IExecutionService, LogReportService>();
             services.AddSingleton<IExecutionService, PingService>();
             services.AddSingleton<IExecutionService, SegmentReportService>();
             services.AddSingleton<IExecutionService, CLRStatsService>();
@@ -66,7 +69,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IConfigurationFactory, ConfigurationFactory>();
             services.AddSingleton<IHostedService, InstrumentationHostedService>();
             services.AddSingleton<IEnvironmentProvider, HostingEnvironmentProvider>();
-            services.AddTracing().AddSampling().AddGrpcTransport().AddSkyApmLogging();
+            services.AddTracing().AddSkyApmLogger().AddSampling().AddGrpcTransport().AddSkyApmLogging();
             var extensions = services.AddSkyApmExtensions()
                  .AddHttpClient()
                  .AddGrpcClient()
@@ -95,6 +98,13 @@ namespace Microsoft.Extensions.DependencyInjection
             return services;
         }
 
+        public static IServiceCollection AddSkyApmLogger(this IServiceCollection services)
+        {
+            services.AddSingleton<ISkyApmLogDispatcher, AsyncQueueSkyApmLogDispatcher>();
+            services.AddSingleton<ILoggerContextContextMapper, LoggerContextContextMapper>();
+            return services;
+        }
+
         private static IServiceCollection AddSampling(this IServiceCollection services)
         {
             services.AddSingleton<SimpleCountSamplingInterceptor>();
@@ -108,6 +118,7 @@ namespace Microsoft.Extensions.DependencyInjection
         private static IServiceCollection AddGrpcTransport(this IServiceCollection services)
         {
             services.AddSingleton<ISegmentReporter, SegmentReporter>();
+            services.AddSingleton<ILoggerReporter, LoggerReporter>();
             services.AddSingleton<ICLRStatsReporter, CLRStatsReporter>();
             services.AddSingleton<ConnectionManager>();
             services.AddSingleton<IPingCaller, PingCaller>();
@@ -121,5 +132,6 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ILoggerFactory, DefaultLoggerFactory>();
             return services;
         }
+
     }
 }

--- a/src/SkyApm.Core/Diagnostics/AnonymousObjectAttribute.cs
+++ b/src/SkyApm.Core/Diagnostics/AnonymousObjectAttribute.cs
@@ -16,12 +16,13 @@
  *
  */
 
-using System;
-
 namespace SkyApm.Diagnostics
 {
-    public abstract class ParameterBinder : Attribute, IParameterResolver
+    public class AnonymousObjectAttribute : ParameterBinderAttribute
     {
-        public abstract object Resolve(object value);
+        public override object Resolve(object value)
+        {
+            return value;
+        }
     }
 }

--- a/src/SkyApm.Core/Diagnostics/DiagnosticNameAttribute.cs
+++ b/src/SkyApm.Core/Diagnostics/DiagnosticNameAttribute.cs
@@ -16,13 +16,17 @@
  *
  */
 
+using System;
+
 namespace SkyApm.Diagnostics
 {
-    public class AnonymousObject : ParameterBinder
+    public class DiagnosticNameAttribute :Attribute
     {
-        public override object Resolve(object value)
+        public string Name { get; }
+
+        public DiagnosticNameAttribute(string name)
         {
-            return value;
+            Name = name;
         }
     }
 }

--- a/src/SkyApm.Core/Diagnostics/ObjectAttribute.cs
+++ b/src/SkyApm.Core/Diagnostics/ObjectAttribute.cs
@@ -20,7 +20,7 @@ using System;
 
 namespace SkyApm.Diagnostics
 {
-    public class ObjectAttribute : ParameterBinder
+    public class ObjectAttribute : ParameterBinderAttribute
     {
         public Type TargetType { get; set; }
 

--- a/src/SkyApm.Core/Diagnostics/ParameterBinderAttribute.cs
+++ b/src/SkyApm.Core/Diagnostics/ParameterBinderAttribute.cs
@@ -20,13 +20,8 @@ using System;
 
 namespace SkyApm.Diagnostics
 {
-    public class DiagnosticName :Attribute
+    public abstract class ParameterBinderAttribute : Attribute, IParameterResolver
     {
-        public string Name { get; }
-
-        public DiagnosticName(string name)
-        {
-            Name = name;
-        }
+        public abstract object Resolve(object value);
     }
 }

--- a/src/SkyApm.Core/Diagnostics/PropertyAttribute.cs
+++ b/src/SkyApm.Core/Diagnostics/PropertyAttribute.cs
@@ -20,7 +20,7 @@ using AspectCore.Extensions.Reflection;
 
 namespace SkyApm.Diagnostics
 {
-    public class PropertyAttribute : ParameterBinder
+    public class PropertyAttribute : ParameterBinderAttribute
     {
         public string Name { get; set; }
 

--- a/src/SkyApm.Core/Diagnostics/TracingDiagnosticMethod.cs
+++ b/src/SkyApm.Core/Diagnostics/TracingDiagnosticMethod.cs
@@ -61,7 +61,7 @@ namespace SkyApm.Diagnostics
         {
             foreach (var parameter in methodInfo.GetParameters())
             {
-                var binder = parameter.GetCustomAttribute<ParameterBinder>();
+                var binder = parameter.GetCustomAttribute<ParameterBinderAttribute>();
                 if (binder != null)
                 {
                     if(binder is ObjectAttribute objectBinder)

--- a/src/SkyApm.Core/Diagnostics/TracingDiagnosticMethodCollection.cs
+++ b/src/SkyApm.Core/Diagnostics/TracingDiagnosticMethodCollection.cs
@@ -31,7 +31,7 @@ namespace SkyApm.Diagnostics
             _methods = new List<TracingDiagnosticMethod>();
             foreach (var method in tracingDiagnosticProcessor.GetType().GetMethods())
             {
-                var diagnosticName = method.GetCustomAttribute<DiagnosticName>();
+                var diagnosticName = method.GetCustomAttribute<DiagnosticNameAttribute>();
                 if(diagnosticName==null)
                     continue;
                 _methods.Add(new TracingDiagnosticMethod(tracingDiagnosticProcessor, method, diagnosticName.Name));

--- a/src/SkyApm.Core/Service/LogReportService.cs
+++ b/src/SkyApm.Core/Service/LogReportService.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Config;
+using SkyApm.Logging;
+using SkyApm.Transport;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SkyApm.Service
+{
+    public class LogReportService : ExecutionService
+    {
+
+        private readonly ISkyApmLogDispatcher _dispatcher;
+        private readonly TransportConfig _config;
+        public LogReportService(IConfigAccessor configAccessor, ISkyApmLogDispatcher dispatcher,
+            IRuntimeEnvironment runtimeEnvironment, ILoggerFactory loggerFactory)
+            : base(runtimeEnvironment, loggerFactory)
+        {
+            _dispatcher = dispatcher;
+            _config = configAccessor.Get<TransportConfig>();
+            Period = TimeSpan.FromMilliseconds(_config.Interval);
+        }
+
+        protected override TimeSpan DueTime { get; } = TimeSpan.FromSeconds(3);
+
+        protected override TimeSpan Period { get; }
+
+        protected override Task ExecuteAsync(CancellationToken cancellationToken)
+        {
+            return _dispatcher.Flush(cancellationToken);
+        }
+        protected override Task Stopping(CancellationToken cancellationToke)
+        {
+            _dispatcher.Close();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/SkyApm.Core/SkyApm.Core.csproj
+++ b/src/SkyApm.Core/SkyApm.Core.csproj
@@ -12,6 +12,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <DefineConstants Condition="'$(TargetFramework)' == 'netcoreapp2.1'">$(DefineConstants);SPAN</DefineConstants>
   </PropertyGroup>
+	
   <ItemGroup>
     <PackageReference Include="AspectCore.Extensions.Reflection" Version="1.2.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />

--- a/src/SkyApm.Core/Tracing/SegmentContextFactory.cs
+++ b/src/SkyApm.Core/Tracing/SegmentContextFactory.cs
@@ -78,8 +78,8 @@ namespace SkyApm.Tracing
                 };
                 segmentContext.References.Add(segmentReference);
             }
-
             _entrySegmentContextAccessor.Context = segmentContext;
+
             return segmentContext;
         }
 

--- a/src/SkyApm.Core/Transport/AsyncQueueSkyApmLogDispatcher.cs
+++ b/src/SkyApm.Core/Transport/AsyncQueueSkyApmLogDispatcher.cs
@@ -1,0 +1,105 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Config;
+using SkyApm.Logging;
+using SkyApm.Tracing.Segments;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SkyApm.Transport
+{
+    public class AsyncQueueSkyApmLogDispatcher : ISkyApmLogDispatcher
+    {
+        private readonly ILogger _logger;
+        private readonly CancellationTokenSource _cancellation;
+
+        private readonly ConcurrentQueue<LoggerRequest> _segmentQueue;
+
+        private readonly IRuntimeEnvironment _runtimeEnvironment;
+
+        private readonly ILoggerReporter _loggerReporter;
+
+        private readonly ILoggerContextContextMapper _loggerContextContextMapper;
+
+        private readonly TransportConfig _config;
+
+        private int _offset;
+
+        public AsyncQueueSkyApmLogDispatcher(IConfigAccessor configAccessor, ILoggerFactory loggerFactory, ILoggerContextContextMapper loggerContextContextMapper, ILoggerReporter loggerReporter, IRuntimeEnvironment runtimeEnvironment)
+        {
+            _logger = loggerFactory.CreateLogger(typeof(AsyncQueueSkyApmLogDispatcher));
+            _config = configAccessor.Get<TransportConfig>();
+            _loggerContextContextMapper = loggerContextContextMapper;
+            _runtimeEnvironment = runtimeEnvironment;
+            _segmentQueue = new ConcurrentQueue<LoggerRequest>();
+            _cancellation = new CancellationTokenSource();
+            _loggerReporter= loggerReporter;
+        }
+
+        public bool Dispatch(LoggerContext loggerContext)
+        {
+            if (!_runtimeEnvironment.Initialized || loggerContext == null)
+                return false;
+
+            // todo performance optimization for ConcurrentQueue
+            if (_config.QueueSize < _offset || _cancellation.IsCancellationRequested)
+                return false;
+
+            var segment = _loggerContextContextMapper.Map(loggerContext);
+
+            if (segment == null)
+                return false;
+
+            _segmentQueue.Enqueue(segment);
+
+            Interlocked.Increment(ref _offset);
+
+            _logger.Debug($"Dispatch trace segment. [SegmentId]={loggerContext.SegmentContext.SegmentId}.");
+            return true;
+        }
+
+        public Task Flush(CancellationToken token = default)
+        {
+            var limit = _config.BatchSize;
+            var index = 0;
+            var logges = new List<LoggerRequest>(limit);
+            while (index++ < limit && _segmentQueue.TryDequeue(out var request))
+            {
+                logges.Add(request);
+                Interlocked.Decrement(ref _offset);
+            }
+
+            // send async
+            if (logges.Count > 0)
+            {
+                _loggerReporter.ReportAsync(logges, token);
+            }
+
+            Interlocked.Exchange(ref _offset, _segmentQueue.Count);
+
+            return Task.CompletedTask;
+        }
+        public void Close()
+        {
+            _cancellation.Cancel();
+        }
+    }
+}

--- a/src/SkyApm.Core/Transport/LoggerContextContextMapper.cs
+++ b/src/SkyApm.Core/Transport/LoggerContextContextMapper.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Tracing.Segments;
+
+namespace SkyApm.Transport
+{
+    public class LoggerContextContextMapper : ILoggerContextContextMapper
+    {
+        private readonly ISegmentContextMapper _segmentContextMapper;
+
+        public LoggerContextContextMapper(ISegmentContextMapper segmentContextMapper)
+        {
+            _segmentContextMapper = segmentContextMapper;
+        }
+
+        public LoggerRequest Map(LoggerContext loggerContext)
+        {
+            var segmentRequest = _segmentContextMapper.Map(loggerContext.SegmentContext);
+            return new LoggerRequest
+            {
+                Logs = loggerContext.Logs,
+                SegmentRequest = segmentRequest,
+            };
+        }
+    }
+}

--- a/src/SkyApm.Core/Transport/LoggerContextContextMapper.cs
+++ b/src/SkyApm.Core/Transport/LoggerContextContextMapper.cs
@@ -36,6 +36,7 @@ namespace SkyApm.Transport
             {
                 Logs = loggerContext.Logs,
                 SegmentRequest = segmentRequest,
+                Date = loggerContext.Date,
             };
         }
     }

--- a/src/SkyApm.Diagnostics.FreeSql/FreeSqlTracingDiagnosticProcessor.cs
+++ b/src/SkyApm.Diagnostics.FreeSql/FreeSqlTracingDiagnosticProcessor.cs
@@ -105,7 +105,7 @@ namespace SkyApm.Diagnostics.FreeSql
             var context = _localSegmentContextAccessor.Context;
             if (context != null)
             {
-                if (string.IsNullOrEmpty(eventData.Sql) == false)
+                if (!string.IsNullOrEmpty(eventData.Sql))
                     context.Span.AddTag(Common.Tags.DB_STATEMENT, eventData.Sql);
                 if (eventData?.Exception != null)
                     context.Span.ErrorOccurred(eventData.Exception, _tracingConfig);
@@ -127,7 +127,7 @@ namespace SkyApm.Diagnostics.FreeSql
             var context = _localSegmentContextAccessor.Context;
             if (context != null)
             {
-                if (string.IsNullOrEmpty(eventData.Log) == false)
+                if (!string.IsNullOrEmpty(eventData.Log))
                     context.Span.AddTag(Common.Tags.DB_STATEMENT, eventData.Log);
                 if (eventData?.Exception != null)
                     context.Span.ErrorOccurred(eventData.Exception, _tracingConfig);
@@ -149,7 +149,7 @@ namespace SkyApm.Diagnostics.FreeSql
             var context = _localSegmentContextAccessor.Context;
             if (context != null)
             {
-                if (string.IsNullOrEmpty(eventData.Remark) == false)
+                if (!string.IsNullOrEmpty(eventData.Remark))
                     context.Span.AddTag(Common.Tags.DB_STATEMENT, eventData.Remark);
                 if (eventData?.Exception != null)
                     context.Span.ErrorOccurred(eventData.Exception, _tracingConfig);

--- a/src/SkyApm.Diagnostics.Grpc/Client/ClientDiagnosticInterceptor.cs
+++ b/src/SkyApm.Diagnostics.Grpc/Client/ClientDiagnosticInterceptor.cs
@@ -54,7 +54,7 @@ namespace SkyApm.Diagnostics.Grpc.Client
                     catch (Exception ex)
                     {
                         _processor.DiagnosticUnhandledException(ex);
-                        throw ex;
+                        throw;
                     }
                 });
                 return new AsyncUnaryCall<TResponse>(responseAsync, response.ResponseHeadersAsync, response.GetStatus, response.GetTrailers, response.Dispose);
@@ -101,7 +101,7 @@ namespace SkyApm.Diagnostics.Grpc.Client
             catch (Exception ex)
             {
                 _processor.DiagnosticUnhandledException(ex);
-                throw ex;
+                throw;
             }
         }
     }

--- a/src/SkyApm.Diagnostics.Grpc/Server/ServerDiagnosticInterceptor.cs
+++ b/src/SkyApm.Diagnostics.Grpc/Server/ServerDiagnosticInterceptor.cs
@@ -36,7 +36,7 @@ namespace SkyApm.Diagnostics.Grpc.Server
         {
              _processor.BeginRequest(context);
 
-            return await Handler<TRequest, TResponse>(context, async () =>
+            return await Handler(context, async () =>
             {
                 return await continuation(request, context);
             });
@@ -44,7 +44,7 @@ namespace SkyApm.Diagnostics.Grpc.Server
 
         public override async Task<TResponse> ClientStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, ServerCallContext context, ClientStreamingServerMethod<TRequest, TResponse> continuation)
         {
-            return await Handler<TRequest, TResponse>(context, async () =>
+            return await Handler(context, async () =>
             {
                 return await continuation(requestStream, context);
             });
@@ -52,7 +52,7 @@ namespace SkyApm.Diagnostics.Grpc.Server
 
         public override async Task ServerStreamingServerHandler<TRequest, TResponse>(TRequest request, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, ServerStreamingServerMethod<TRequest, TResponse> continuation)
         {
-            await Handler<TRequest>(context, async () =>
+            await Handler(context, async () =>
             {
                 await continuation(request, responseStream, context);
             });
@@ -60,14 +60,13 @@ namespace SkyApm.Diagnostics.Grpc.Server
 
         public override async Task DuplexStreamingServerHandler<TRequest, TResponse>(IAsyncStreamReader<TRequest> requestStream, IServerStreamWriter<TResponse> responseStream, ServerCallContext context, DuplexStreamingServerMethod<TRequest, TResponse> continuation)
         {
-            await Handler<TRequest>(context, async () =>
+            await Handler(context, async () =>
             {
                 await continuation(requestStream, responseStream, context);
             });
         }
 
-        private async Task Handler<TRequest>(ServerCallContext context, Func<Task> func) 
-            where TRequest : class
+        private async Task Handler(ServerCallContext context, Func<Task> func)
         {
             _processor.BeginRequest(context);
             try
@@ -78,12 +77,11 @@ namespace SkyApm.Diagnostics.Grpc.Server
             catch (Exception ex)
             {
                 _processor.DiagnosticUnhandledException(ex);
-                throw ex;
+                throw;
             }
         }
 
-        private async Task<TResponse> Handler<TRequest, TResponse>(ServerCallContext context, Func<Task<TResponse>> func)
-            where TRequest : class
+        private async Task<TResponse> Handler<TResponse>(ServerCallContext context, Func<Task<TResponse>> func)
             where TResponse : class
         {
             _processor.BeginRequest(context);
@@ -96,7 +94,7 @@ namespace SkyApm.Diagnostics.Grpc.Server
             catch (Exception ex)
             {
                 _processor.DiagnosticUnhandledException(ex);
-                throw ex;
+                throw;
             }
         }
     }

--- a/src/SkyApm.Diagnostics.Logging/ISkyApmLogger.cs
+++ b/src/SkyApm.Diagnostics.Logging/ISkyApmLogger.cs
@@ -1,0 +1,11 @@
+﻿using SkyApm.Logging;
+
+namespace SkyApm.Diagnostics.Logging
+{
+    public interface ISkyApmLogger<out TCategoryName> :ILogger
+    {
+
+
+
+    }
+}

--- a/src/SkyApm.Diagnostics.Logging/ServiceCollectionExtensions.cs
+++ b/src/SkyApm.Diagnostics.Logging/ServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+﻿using SkyApm.Config;
+using SkyApm.Diagnostics.Logging;
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class ServiceCollectionExtensions
+    {
+
+        public static IServiceCollection AddPushSkyApmLogger(this IServiceCollection services, Action<LogPushSkywalkingConfig> action)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+            if (action == null)
+            {
+                throw new ArgumentNullException(nameof(action));
+            }
+            LogPushSkywalkingConfig logPushSkywalking = new LogPushSkywalkingConfig();
+            action.Invoke(logPushSkywalking);
+            services.Configure(action);
+
+            services.Add(new ServiceDescriptor(typeof(ISkyApmLogger<>), typeof(SkyApmLogger<>), ServiceLifetime.Singleton));
+            return services;
+        }
+    }
+}

--- a/src/SkyApm.Diagnostics.Logging/SkyApm.Diagnostics.Logging.csproj
+++ b/src/SkyApm.Diagnostics.Logging/SkyApm.Diagnostics.Logging.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+	  <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SkyApm.Abstractions\SkyApm.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SkyApm.Diagnostics.Logging/SkyApmLogger.cs
+++ b/src/SkyApm.Diagnostics.Logging/SkyApmLogger.cs
@@ -62,6 +62,7 @@ namespace SkyApm.Diagnostics.Logging
                 {
                     Logs = logs,
                     SegmentContext = _entrySegmentContextAccessor.Context,
+                    Date = DateTimeOffset.UtcNow.Offset.Ticks
                 };
                 _skyApmLogDispatcher.Dispatch(logContext);
             }

--- a/src/SkyApm.Diagnostics.Logging/SkyApmLogger.cs
+++ b/src/SkyApm.Diagnostics.Logging/SkyApmLogger.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Extensions.Options;
+using SkyApm.Config;
+using SkyApm.Logging;
+using SkyApm.Tracing;
+using SkyApm.Tracing.Segments;
+using SkyApm.Transport;
+using System;
+using System.Collections.Generic;
+
+namespace SkyApm.Diagnostics.Logging
+{
+
+    public class SkyApmLogger <TCategoryName> : ISkyApmLogger<TCategoryName>
+    {
+
+        private readonly bool _pushSkywalking;
+        private readonly Type _loggerName;
+        private readonly IEntrySegmentContextAccessor _entrySegmentContextAccessor;
+        private readonly ISkyApmLogDispatcher _skyApmLogDispatcher;
+        public SkyApmLogger(IEntrySegmentContextAccessor entrySegmentContextAccessor, ISkyApmLogDispatcher skyApmLogDispatcher, IOptions<LogPushSkywalkingConfig> logPushSkywalkingConfig)
+        {
+            _loggerName = typeof(TCategoryName);
+            _entrySegmentContextAccessor = entrySegmentContextAccessor;
+            _skyApmLogDispatcher = skyApmLogDispatcher;
+            _pushSkywalking = logPushSkywalkingConfig.Value.Enable;
+        }
+
+        public void Debug(string message)
+        {
+            SendLog("Debug", message);
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            SendLog("Error", message);
+        }
+
+        public void Information(string message)
+        {
+            SendLog("Information", message);
+        }
+
+        public void Trace(string message)
+        {
+            SendLog("Trace", message);
+        }
+
+        public void Warning(string message)
+        {
+            SendLog("Warning", message);
+        }
+
+        private void SendLog(string logLevel, string message)
+        {
+            if (_pushSkywalking)
+            {
+                var logs = new Dictionary<string, object>();
+                logs.Add("className", _loggerName);
+                logs.Add("Level", logLevel);
+                logs.Add("logMessage", message);
+                var logContext = new LoggerContext()
+                {
+                    Logs = logs,
+                    SegmentContext = _entrySegmentContextAccessor.Context,
+                };
+                _skyApmLogDispatcher.Dispatch(logContext);
+            }
+
+        }
+
+    }
+
+    //public class SkyApmLoggerFactory : ILoggerFactory
+    //{
+    //    public ILogger CreateLogger(Type type)
+    //    {
+    //        throw new NotImplementedException();
+    //    }
+    //}
+}

--- a/src/SkyApm.Diagnostics.MongoDB/DiagnosticsActivityEventSubscriber.cs
+++ b/src/SkyApm.Diagnostics.MongoDB/DiagnosticsActivityEventSubscriber.cs
@@ -27,7 +27,7 @@ namespace SkyApm.Diagnostics.MongoDB
 {
     public class DiagnosticsActivityEventSubscriber : IEventSubscriber
     {
-        public static DiagnosticSource diagnosticSource = new DiagnosticListener("MongoSourceListener");
+        private static DiagnosticSource diagnosticSource = new DiagnosticListener("MongoSourceListener");
         internal static readonly AssemblyName AssemblyName = typeof(DiagnosticsActivityEventSubscriber).Assembly.GetName();
         internal static readonly string ActivitySourceName = AssemblyName.Name;
         internal static readonly Version Version = AssemblyName.Version;
@@ -71,10 +71,7 @@ namespace SkyApm.Diagnostics.MongoDB
                 return;
             }
             var activity = new Activity("MongoActivity");
-            if (activity == null)
-            {
-                return;
-            }
+            
             _activityMap.TryAdd(@event.RequestId, activity);
             diagnosticSource.StartActivity(activity, @event);
         }

--- a/src/SkyApm.Transport.Grpc/Common/SegmentV8Helpers.cs
+++ b/src/SkyApm.Transport.Grpc/Common/SegmentV8Helpers.cs
@@ -20,7 +20,11 @@ using System;
 using System.Linq;
 using Google.Protobuf;
 using SkyApm.Common;
+using SkyApm.Tracing.Segments;
 using SkyWalking.NetworkProtocol.V3;
+using SegmentReference = SkyWalking.NetworkProtocol.V3.SegmentReference;
+using SpanLayer = SkyWalking.NetworkProtocol.V3.SpanLayer;
+using SpanType = SkyWalking.NetworkProtocol.V3.SpanType;
 
 namespace SkyApm.Transport.Grpc.Common
 {
@@ -67,7 +71,7 @@ namespace SkyApm.Transport.Grpc.Common
 
         private static SegmentReference MapToSegmentReference(SegmentReferenceRequest referenceRequest)
         {
-            var reference = new SegmentReference
+            var reference = new SkyWalking.NetworkProtocol.V3.SegmentReference
             {
                 TraceId = referenceRequest.TraceId, 
                 ParentService = referenceRequest.ParentServiceId, 

--- a/src/SkyApm.Transport.Grpc/V8/LoggerReporter.cs
+++ b/src/SkyApm.Transport.Grpc/V8/LoggerReporter.cs
@@ -1,0 +1,109 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using SkyApm.Config;
+using SkyApm.Logging;
+using SkyWalking.NetworkProtocol.V3;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SkyApm.Transport.Grpc
+{
+    public class LoggerReporter : ILoggerReporter
+    {
+
+        private readonly ConnectionManager _connectionManager;
+        private readonly ILogger _logger;
+        private readonly GrpcConfig _config;
+
+        public LoggerReporter(ConnectionManager connectionManager, IConfigAccessor configAccessor,
+            ILoggerFactory loggerFactory)
+        {
+            _connectionManager = connectionManager;
+            _config = configAccessor.Get<GrpcConfig>();
+            _logger = loggerFactory.CreateLogger(typeof(SegmentReporter));
+        }
+
+
+        public async Task ReportAsync(IReadOnlyCollection<LoggerRequest> loggerRequests, CancellationToken cancellationToken = default)
+        {
+            if (!_connectionManager.Ready)
+            {
+                return;
+            }
+
+            var connection = _connectionManager.GetConnection();
+            try
+            {
+                var stopwatch = Stopwatch.StartNew();
+                var client = new LogReportService.LogReportServiceClient(connection);
+                using (var asyncClientStreamingCall = client.collect(_config.GetMeta(), _config.GetReportTimeout(), cancellationToken))
+                {
+                    foreach (var loggerRequest in loggerRequests)
+                    {
+                        StringBuilder logmessage=new StringBuilder();
+                        foreach (var log in loggerRequest.Logs)
+                        {
+                            logmessage.Append($"\r\n{log.Key} : {log.Value}");
+                        }
+                        var logbody = new LogData()
+                        {
+                            TraceContext = new TraceContext()
+                            {
+                                TraceId = loggerRequest.SegmentRequest.TraceId,
+                                TraceSegmentId = loggerRequest.SegmentRequest.Segment.SegmentId,
+                                //SpanId=item.Segment
+                            },
+                            Timestamp = DateTimeOffset.UtcNow.Ticks,
+                            Service = loggerRequest.SegmentRequest.Segment.ServiceId,
+                            ServiceInstance = loggerRequest.SegmentRequest.Segment.ServiceInstanceId,
+                            Endpoint = "",
+                            Body = new LogDataBody()
+                            {
+                                Type = "text",
+                                Text = new TextLog()
+                                {
+                                    Text = logmessage.ToString(),
+                                },
+                            },
+                        };
+                        await asyncClientStreamingCall.RequestStream.WriteAsync(logbody);
+                    }
+
+                    await asyncClientStreamingCall.RequestStream.CompleteAsync();
+                    await asyncClientStreamingCall.ResponseAsync;
+
+                    stopwatch.Stop();
+                    _logger.Information($"Report {loggerRequests.Count} logger logger. cost: {stopwatch.Elapsed}s");
+                }
+
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Report trace segment fail.", ex);
+                _connectionManager.Failure(ex);
+
+            }
+
+        }
+    }
+}

--- a/src/SkyApm.Transport.Grpc/V8/LoggerReporter.cs
+++ b/src/SkyApm.Transport.Grpc/V8/LoggerReporter.cs
@@ -73,7 +73,7 @@ namespace SkyApm.Transport.Grpc
                                 TraceSegmentId = loggerRequest.SegmentRequest.Segment.SegmentId,
                                 //SpanId=item.Segment
                             },
-                            Timestamp = DateTimeOffset.UtcNow.Ticks,
+                            Timestamp = loggerRequest.Date,
                             Service = loggerRequest.SegmentRequest.Segment.ServiceId,
                             ServiceInstance = loggerRequest.SegmentRequest.Segment.ServiceInstanceId,
                             Endpoint = "",

--- a/src/SkyApm.Transport.Grpc/V8/SegmentReporter.cs
+++ b/src/SkyApm.Transport.Grpc/V8/SegmentReporter.cs
@@ -64,7 +64,6 @@ namespace SkyApm.Transport.Grpc.V8
                     await asyncClientStreamingCall.RequestStream.CompleteAsync();
                     await asyncClientStreamingCall.ResponseAsync;
                 }
-
                 stopwatch.Stop();
                 _logger.Information($"Report {segmentRequests.Count} trace segment. cost: {stopwatch.Elapsed}s");
             }

--- a/src/SkyApm.Utilities.Logging/SkyApm.Utilities.Logging.csproj
+++ b/src/SkyApm.Utilities.Logging/SkyApm.Utilities.Logging.csproj
@@ -12,6 +12,9 @@
         </PackageReleaseNotes>
         <RootNamespace>SkyApm.Utilities.Logging</RootNamespace>
     </PropertyGroup>
+    <ItemGroup>
+      <Compile Remove="SkyApmLogger.cs" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />

--- a/src/SkyApm.Utilities.Logging/SkyApmLogger.cs
+++ b/src/SkyApm.Utilities.Logging/SkyApmLogger.cs
@@ -1,0 +1,86 @@
+﻿/*
+ * Licensed to the SkyAPM under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The SkyAPM licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+using Microsoft.Extensions.DependencyInjection;
+using SkyApm.Logging;
+using SkyApm.Tracing;
+using SkyApm.Tracing.Segments;
+using SkyApm.Transport;
+using System;
+using System.Collections.Generic;
+
+namespace SkyApm.Utilities.Logging
+{
+    public class SkyApmLogger : ILogger
+    {
+        private readonly Type _loggerName;
+        private readonly IEntrySegmentContextAccessor _entrySegmentContextAccessor;
+        private readonly ISkyApmLogDispatcher _skyApmLogDispatcher;
+        private readonly bool _pushSkywalking;
+        public SkyApmLogger(Type type, IServiceProvider serviceProvider,bool pushSkywalking)
+        {
+            _entrySegmentContextAccessor = serviceProvider.GetService<IEntrySegmentContextAccessor>();
+            _skyApmLogDispatcher = serviceProvider.GetService<ISkyApmLogDispatcher>();
+            _loggerName = type;
+            _pushSkywalking= pushSkywalking;
+        }
+
+        public void Debug(string message)
+        {
+            SendLog("Debug", message);
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            SendLog("Error", message);
+        }
+
+        public void Information(string message)
+        {
+            SendLog("Information", message);
+        }
+
+        public void Trace(string message)
+        {
+            SendLog("Trace", message);
+        }
+
+        public void Warning(string message)
+        {
+            SendLog("Warning", message);
+        }
+
+        private void SendLog(string logLevel, string message)
+        {
+            if(_pushSkywalking)
+            {
+                var logs = new Dictionary<string, object>();
+                logs.Add("className", _loggerName);
+                logs.Add("Level", logLevel);
+                logs.Add("logMessage", message);
+                var logContext = new LoggerContext()
+                {
+                    Logs = logs,
+                    SegmentContext = _entrySegmentContextAccessor.Context,
+                };
+                _skyApmLogDispatcher.Dispatch(logContext);
+            }
+            
+        }
+    }
+}


### PR DESCRIPTION
Please answer these questions before submitting pull request

- Why submit this pull request?
- [x] Bug fix
- [x] New feature provided
- [ ] Improve performance

- Related issues

___
### Bug fix
- Bug description.
`Local SegmentContext` can only be mounted to `Entry SegmentContext`
```csharp
[HttpGet]
[Route("/test")]
public async Task<string> Get()
{
    var parentLocalSegment = _tracingContext.CreateLocalSegmentContext("parent");

    var childLocalSegment = _tracingContext.CreateLocalSegmentContext("child");
    _tracingContext.Release(childLocalSegment);

    _tracingContext.Release(parentLocalSegment);

    return "ok";
}
```
![image](https://user-images.githubusercontent.com/15099549/167124663-14d601c4-5cf5-4dfc-ae94-a7957be41f9d.png)
- How to fix?
Comment the following line.

https://github.com/SkyAPM/SkyAPM-dotnet/blob/8cfe8e8ee421c2287f514f69804a423944dd1920/src/SkyApm.Core/Tracing/SegmentContextFactory.cs#L231

after comment:
![image](https://user-images.githubusercontent.com/15099549/167125577-90b27d40-7544-46c1-a8d6-e062fe05902b.png)

___
### New feature or improvement
- Describe the details and related test reports.
#### Span Structure
Our current logic is to create a `SegmentContext` for each `span`. This can indeed handle the complex async/await in .NET, but the `segmentId` cannot be sorted, which will cause our trace to look out of order.
https://github.com/inversionhourglass/SkyAPM-dotnet/blob/7c135c3dd8534e877f606694eb6d8e70f47aab21/sample/SkyApm.Sample.Frontend/Controllers/TestController.cs#L82-L93
![image](https://user-images.githubusercontent.com/15099549/167126447-fb918cf4-dfbf-4269-a8f4-b2a76a8fcb2a.png)

I spent some time writing a set of interfaces based on `span` as the main structure. The structure can be switched by configuration `SkyWalking:StructType`. The default value is `segment`, you can change to `span`. The span structure is not perfect. In some cases, it will be ugly. The following is an introduction to various situations.

1. general case
The example I gave you at the beginning.
![image](https://user-images.githubusercontent.com/15099549/167128978-57d201c5-9d2c-4567-8a18-54f6fb303e54.png)
This is the best and simplest example and everything works fine.

2. async method does not have await, but completes before parent span completes
https://github.com/inversionhourglass/SkyAPM-dotnet/blob/7c135c3dd8534e877f606694eb6d8e70f47aab21/sample/SkyApm.Sample.Frontend/Controllers/TestController.cs#L111-L122
![image](https://user-images.githubusercontent.com/15099549/167129663-e632c07e-9cd5-45ae-bc94-66113357d14f.png)
There's nothing wrong with this.

3. async method has no await and neither completes when parent span complete
https://github.com/inversionhourglass/SkyAPM-dotnet/blob/7c135c3dd8534e877f606694eb6d8e70f47aab21/sample/SkyApm.Sample.Frontend/Controllers/TestController.cs#L124-L135
![image](https://user-images.githubusercontent.com/15099549/167130021-350151bf-2a98-4b77-9db0-1494cc82318b.png)
As you see, `HttpDelayWrap` and `http://127.0.0.1:5001/test/delay` is marked as `[async]`, because they are not completed before the parent span to complete.

4. The async method has no await and is completed a long time after the parent span has completed
https://github.com/inversionhourglass/SkyAPM-dotnet/blob/7c135c3dd8534e877f606694eb6d8e70f47aab21/sample/SkyApm.Sample.Frontend/Controllers/TestController.cs#L137-L148
![image](https://user-images.githubusercontent.com/15099549/167132306-1d2f7019-37db-4eb2-b17c-b2470eb826ab.png)
As you see, in addition to the `[async]` flag, there are flags like `[async-1]`, and `WrappedHttpDelayAsync-after` becomes their child span. In fact, this is what it looks like without await. The result of case 3 is merged by [AsyncSpanCombiner](https://github.com/inversionhourglass/SkyAPM-dotnet/blob/master/src/SkyApm.Core/Tracing/AsyncSpanCombiner.cs). Because of `AsyncSpanCombiner`, the generated trace data will be delayed and reported to the oap-server for a period of time. This time can be configured through `SkyWalking:SpanStructure:MergeDelay`, the default is 5000(ms).

5. not await and not await
https://github.com/inversionhourglass/SkyAPM-dotnet/blob/7c135c3dd8534e877f606694eb6d8e70f47aab21/sample/SkyApm.Sample.Frontend/Controllers/TestController.cs#L166-L193
![image](https://user-images.githubusercontent.com/15099549/167134917-ab13b306-d9da-420a-ace5-feecfb8a9a91.png)
This code will generate three segments, the first two have shorter intervals, so the second will be merged into the first, and the third interval exceeds the merge wait time, so no merge is performed, but the third associated parent The segment is the second, and the second is merged into the first, so the third cannot find the parent segment.

You can find more test case in [TestController](https://github.com/inversionhourglass/SkyAPM-dotnet/blob/master/sample/SkyApm.Sample.Frontend/Controllers/TestController.cs).

Compared with `SegmentContext`, `Span` can guarantee order and can produce less segment data, but as in the previous example, some cases will produce extra nodes (as [async-1] in example 4), some cases can cause traces to not be associated (as in example 5). In addition, not all data will be delayed in merge, only if there are asynchronous incomplete subtasks. 

#### UI changes
This feature may cause the spanId in the same segment to be discontinuous. In the current UI version 8.x, there is a logic to check the continuous spanId, so I additionally modified part of the logic of rocketbot-ui and submitted a [pullrequest](https://github.com/apache/skywalking-rocketbot-ui/pull/571).

#### Interface changes
In this feature, I marked `ITracingContext.CreateEntrySegmentContext`, `ITracingContext.CreateLocalSegmentContext`, `ITracingContext.CreateExitSegmentContext`, `ITracingContext.Release` as [Obsolete], it will be replaced with `ITracingContext.CreateEntry`, `ITracingContext.CreateLocal`, `ITracingContext.CreateExit`, `ITracingContext.Finish` and it will decide whether the main structure is `SegmentSpan` or `SegmentContext` according to the configuration.

#### Threading Extensions
In order to avoid the situation in examples 4 and 5, we can manually place the asynchronous non-await method into a task, and then associate the task with the current segment as a new segment. In order to simplify the operation of creating a segment, right The threading series of classes have been extended.
https://github.com/inversionhourglass/SkyAPM-dotnet/blob/7c135c3dd8534e877f606694eb6d8e70f47aab21/sample/SkyApm.Sample.Frontend/Controllers/TestController.cs#L216-L235

#### Static Accessor
Sometimes we may need to create spans in static methods or where IoC cannot be used (such as Threading Extensions), so I created [SkyApmInstances](https://github.com/inversionhourglass/SkyAPM-dotnet/blob/master/src/SkyApm.Utilities.StaticAccessor/SkyApmInstances.cs), which can access the `ITracingContext` through `SkyApmInstances.TracingContext`. To use this feature, you need to refer to `SkyApm.Utilities.StaticAccessor` and Register in startup `services.AddSkyAPMStaticAccessor();`.